### PR TITLE
add tier.schedule(), deprecate subscribe overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ versioned plan names.
 If no effective date is provided, then the plan is effective
 immediately.
 
-### `subscribe(org, phases)`
+### `schedule(org, phases)`
 
-Subscribe an org to each of the sets of plans specified in the
-`phases` array.
+Create a subscription schedule phase for each of the sets of
+plans specified in the `phases` array.
 
 Each item in `phases` must be an object containing:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,19 +157,21 @@ export async function report(
   return tier.report(org, feature, n, at, clobber)
 }
 
-export async function subscribe(org: OrgName, phases: Phase[]): Promise<string>
 export async function subscribe(
   org: OrgName,
   features: Features | Features[],
   effective?: Date
-): Promise<string>
-export async function subscribe(
-  org: OrgName,
-  featuresOrPhases: Features | Features[] | Phase[],
-  effective?: Date
 ): Promise<{}> {
   const tier = await getClient()
-  return tier.subscribe(org, featuresOrPhases, effective)
+  return await tier.subscribe(org, features, effective)
+}
+
+export async function schedule(
+  org: OrgName,
+  phases: Phase[]
+): Promise<{}> {
+  const tier = await getClient()
+  return await tier.schedule(org, phases)
 }
 
 export async function whois(org: OrgName): Promise<WhoIsResponse> {
@@ -222,6 +224,7 @@ const TIER = {
   push,
   report,
   subscribe,
+  schedule,
   whois,
 }
 


### PR DESCRIPTION
Previously, tier.subscribe() was doing double-duty.  It still is, just to keep the function from being a breaking change (though it does still break the type signature, I guess? but unlikely anyone is using that yet) while moving the "advanced" scheduling use case to tier.schedule(), which *only* takes an array of phases, no separate effective date.