### PR TITLE
build hybrid module for cjs/mjs ease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 /*
 /.*
 /lib
+/dist
 !/.naverc
-!/tsconfig.json
+!/tsconfig*.json
+!/fixup.sh
 !/cli-packages
 !/bin
 !/src

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ can load and instantiate the client:
 ```ts
 import { Tier } from 'tier/client'
 // or, if you don't have import maps:
-// import { Tier } from 'https://unpkg.com/tier@^3.1.0/lib/client.js'
+// import { Tier } from 'https://unpkg.com/tier@^3.2.0/dist/mjs/client.js'
 
 const tier = new Tier({
   // Required: the base url to the running `tier serve` instance

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+cat >dist/cjs/package.json <<!EOF
+{
+  "type": "commonjs"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+  "type": "module"
+}
+!EOF

--- a/package.json
+++ b/package.json
@@ -2,28 +2,35 @@
   "name": "tier",
   "version": "3.1.0",
   "files": [
-    "lib"
+    "dist"
   ],
-  "main": "lib/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
   "exports": {
-    ".": "./lib/index.js",
-    "./client": "./lib/client.js"
+    ".": {
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./client": {
+      "import": "./dist/mjs/client.js",
+      "require": "./dist/cjs/client.js"
+    }
   },
   "description": "SDK for using https://tier.run in Node.js applications",
   "repository": "https://github.com/tierrun/node-sdk",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "license": "ISC",
   "scripts": {
-    "prepare": "tsc",
+    "prepare": "tsc -p tsconfig-cjs.json && tsc -p tsconfig-esm.json && bash fixup.sh",
     "format": "prettier --write . --loglevel warn",
     "test": "c8 tap test/*.ts",
     "snap": "c8 tap test/*.ts",
-    "pretest": "tsc",
-    "presnap": "tsc",
+    "pretest": "npm run prepare",
+    "presnap": "npm run prepare",
     "preversion": "npm test",
     "postversion": "npm publish",
     "prepublishOnly": "git push origin --follow-tags",
-    "postpublish": "rm -rf lib",
+    "postpublish": "rm -rf dist",
     "typedoc": "typedoc ./src/*.ts"
   },
   "prettier": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type {
   PushResponse,
   Usage,
   WhoIsResponse,
-} from './client'
+} from './client.js'
 
 // just use node-fetch as a polyfill for old node environments
 let fetchPromise: Promise<void> | null = null
@@ -199,9 +199,9 @@ import {
   isTierError,
   isVersionedFeatureName,
   Tier,
-} from './client'
+} from './client.js'
 
-export * from './client'
+export * from './client.js'
 
 const TIER = {
   isErrorResponse,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -4,16 +4,13 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,
-    "target": "ES6",
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "module": "CommonJS",
     "resolveJsonModule": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "lib",
     "allowSyntheticDefaultImports": true
   }
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "es2015"
+  }
+}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/mjs",
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
This makes it so that `import {Tier} from 'tier/client'` works even in environments where there's no `exports` object.

The previous build was using TypeScript's CommonJS output mode, so it assumed a Node target environment.  It would work if you had loaded Deno's node polyfills, but that's not something we'd like to rely on.