### PR TITLE
add cancel, trialDays, and checkout options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,11 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
         platform:
         - os: ubuntu-latest
           shell: bash
         - os: macos-latest
-          shell: bash
-        - os: windows-latest
           shell: bash
         - os: windows-latest
           shell: powershell
@@ -25,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1.1.0
+        uses: actions/checkout@v3
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # change log
 
+## 4.0
+
+- Move growing parameter lists into `SubscribeOptions` and
+  `ScheduleOptions` object params.
+- Add support for `trialDays` option to `tier.subscribe()`
+- Add `tier.cancel()` method
+- Add experimental support for `checkout` option to
+  `tier.subscribe()` and `tier.schedule()`
+
 ## 3.0
 
 - Add `tier.push()` method

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,29 @@
-The ISC License
+BSD 3-Clause License
 
-Copyright (c) 2022-2023 Tier.run, Inc.
+Copyright (c) 2022 - 2023, Tier.run Inc
+All rights reserved.
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ feature that were consumed.
 
 Options object may contain the following fields:
 
-- `at` Date object indicating when the
-  usage took place.
+- `at` Date object indicating when the usage took place.
 - `clobber` boolean indicating that the usage amount should
   override any previously reported usage of the feature for the
   current subscription phase.
@@ -419,11 +418,11 @@ remaining.
 `TierError` is a subclass of `Error` which is raised whenever
 Tier encounters a problem fetching data.
 
-* `message`: the `message` field from the sidear, if present, or
+- `message`: the `message` field from the sidear, if present, or
   `"Tier request failed"`
-* `path`: the path on the sidecar API that was requested
-* `requestData`: the data that was sent to the sidecar
-* `status`: the HTTP response status code from the sidecar, if a
+- `path`: the path on the sidecar API that was requested
+- `requestData`: the data that was sent to the sidecar
+- `status`: the HTTP response status code from the sidecar, if a
   response was returned
-* `code`: response error code returned by the sidecar, if present
-* `responseData`: the raw HTTP body sent by the sidecar
+- `code`: response error code returned by the sidecar, if present
+- `responseData`: the raw HTTP body sent by the sidecar

--- a/README.md
+++ b/README.md
@@ -109,10 +109,9 @@ This Error subclass contains the following fields:
 
 ## API METHODS
 
-### `subscribe(org, plan, [effective, [info]])`
+### `subscribe(org, plan, { info, trialDays, checkout })`
 
-Subscribe an org to the specified plan. If no effective date is
-provided, then the plan is effective immediately.
+Subscribe an org to the specified plan effective immediately.
 
 Plan may be either a versioned plan name, or an array of
 versioned plan names.
@@ -123,21 +122,42 @@ immediately.
 If `info` is provided, it updates the org with info in the same
 way as calling `updateOrg(org, info)`.
 
-### `schedule(org, phases, [info])`
+If `trialDays` is a number greater than 0, then a trial phase
+will be prepended with the same features, and the effective date
+will on the non-trial phase will be delayed until the end of the
+trial period.
+
+**Experimental**: If `checkout` is set to an object with
+`success_url` and `cancel_url` strings, then the response will
+contain a `checkout_url`, and the subscription will not be
+created until the user completes the steps at the provided URL.
+This API is experimental, and may change in a future update.
+
+### `schedule(org, phases, { info, checkout })`
 
 Create a subscription schedule phase for each of the sets of
 plans specified in the `phases` array.
 
 Each item in `phases` must be an object containing:
 
-- `features` Array of plan names
-- `effective` Optional effective date
+- `features` Array of versioned plan names
+- `effective` Optional effective date. Note that the first phase
+  in the list MUST have an effective date of right now (which is
+  the default).
+- `trial` Optional boolean indicating whether this is a trial or
+  an actual billed phase, default `false`
 
 If no effective date is provided, then the phase takes effect
 immediately.
 
 If `info` is provided, it updates the org with info in the same
 way as calling `updateOrg(org, info)`.
+
+**Experimental**: If `checkout` is set to an object with
+`success_url` and `cancel_url` strings, then the response will
+contain a `checkout_url`, and the subscription will not be
+created until the user completes the steps at the provided URL.
+This API is experimental, and may change in a future update.
 
 ### `updateOrg(org, info)`
 
@@ -154,6 +174,11 @@ Update the specified org with the supplied information.
 Note that any string fields that are missing will result in that
 data being removed from the org's Customer record in Stripe, as
 if `''` was specified.
+
+### `cancel(org)`
+
+Immediately cancels all current and pending subscriptions for the
+specified org.
 
 ### `limits(org)`
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ will be prepended with the same features, and the effective date
 will on the non-trial phase will be delayed until the end of the
 trial period.
 
-**Experimental**: If `checkout` is set to an object with
-`success_url` and `cancel_url` strings, then the response will
-contain a `checkout_url`, and the subscription will not be
-created until the user completes the steps at the provided URL.
-This API is experimental, and may change in a future update.
+**Experimental**: If `checkout` is set to an object with a
+`success_url` string and optionally a `cancel_url` string, then
+the response will contain a `checkout_url`, and the subscription
+will not be created until the user completes the steps at the
+provided URL. **This API is experimental, and may change in a
+future update.**
 
 ### `schedule(org, phases, { info, checkout })`
 
@@ -153,11 +154,13 @@ immediately.
 If `info` is provided, it updates the org with info in the same
 way as calling `updateOrg(org, info)`.
 
-**Experimental**: If `checkout` is set to an object with
-`success_url` and `cancel_url` strings, then the response will
-contain a `checkout_url`, and the subscription will not be
-created until the user completes the steps at the provided URL.
-This API is experimental, and may change in a future update.
+**Experimental**: If `checkout` is set to an object with a
+`success_url` string and optionally a `cancel_url` string, then
+the response will contain a `checkout_url`, and the subscription
+will not be created until the user completes the steps at the
+provided URL. **This API is experimental, and may change in a
+future update.**
+
 
 ### `updateOrg(org, info)`
 

--- a/README.md
+++ b/README.md
@@ -141,15 +141,16 @@ plans specified in the `phases` array.
 
 Each item in `phases` must be an object containing:
 
-- `features` Array of versioned plan names
-- `effective` Optional effective date. Note that the first phase
-  in the list MUST have an effective date of right now (which is
-  the default).
+- `features` Array of versioned plan names (for example,
+  `plan:bar@1`), or "feature plan" names (for example,
+  `feature:foo@plan:bar@1`)
+- `effective` Optional effective date.
 - `trial` Optional boolean indicating whether this is a trial or
   an actual billed phase, default `false`
 
 If no effective date is provided, then the phase takes effect
-immediately.
+immediately. Note that the first phase in the list MUST NOT
+have an effective date, and start immediately.
 
 If `info` is provided, it updates the org with info in the same
 way as calling `updateOrg(org, info)`.

--- a/README.md
+++ b/README.md
@@ -413,3 +413,17 @@ consumed.
 
 Number specifying the amount of feature consumption that is
 remaining.
+
+### Class: `TierError`
+
+`TierError` is a subclass of `Error` which is raised whenever
+Tier encounters a problem fetching data.
+
+* `message`: the `message` field from the sidear, if present, or
+  `"Tier request failed"`
+* `path`: the path on the sidecar API that was requested
+* `requestData`: the data that was sent to the sidecar
+* `status`: the HTTP response status code from the sidecar, if a
+  response was returned
+* `code`: response error code returned by the sidecar, if present
+* `responseData`: the raw HTTP body sent by the sidecar

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "description": "SDK for using https://tier.run in Node.js applications",
   "repository": "https://github.com/tierrun/node-sdk",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
-  "license": "ISC",
+  "license": "BSD-3-Clause",
   "scripts": {
     "prepare": "tsc -p tsconfig-cjs.json && tsc -p tsconfig-esm.json && bash fixup.sh",
     "format": "prettier --write . --loglevel warn",

--- a/src/client.ts
+++ b/src/client.ts
@@ -418,9 +418,6 @@ export class Answer {
   ok: boolean
   feature: FeatureName
   org: OrgName
-  used: number
-  limit: number
-  remaining: number
   client: Tier
   err?: TierError
 
@@ -435,14 +432,8 @@ export class Answer {
     this.org = org
     this.feature = feature
     if (usage && !err) {
-      this.used = usage.used
-      this.limit = usage.limit
-      this.remaining = usage.limit - usage.used
-      this.ok = this.used < this.limit
+      this.ok = usage.used < usage.limit
     } else {
-      this.limit = 0
-      this.used = 0
-      this.remaining = 0
       this.ok = true
       this.err = err
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -335,14 +335,14 @@ export interface ScheduleResponse {
   checkout_url?: string
 }
 
-export interface SubscribeOptions {
+export interface SubscribeParams {
   effective?: Date
   info?: OrgInfo
   trialDays?: number
   checkout?: CheckoutParams
 }
 
-export interface ScheduleOptions {
+export interface ScheduleParams {
   info?: OrgInfo
   checkout?: CheckoutParams
 }
@@ -352,7 +352,7 @@ export interface PhasesResponse {
   phases: Phase[]
 }
 
-export interface ReportOptions {
+export interface ReportParams {
   at?: Date
   clobber?: boolean
 }
@@ -439,7 +439,7 @@ export class Answer {
     }
   }
 
-  async report(n: number = 1, options?: ReportOptions) {
+  async report(n: number = 1, options?: ReportParams) {
     return this.client.report(this.org, this.feature, n, options)
   }
 }
@@ -576,7 +576,7 @@ export class Tier {
     org: OrgName,
     feature: FeatureName,
     n: number = 1,
-    { at, clobber }: ReportOptions = {}
+    { at, clobber }: ReportParams = {}
   ): Promise<{}> {
     const req: ReportRequest = {
       org,
@@ -593,7 +593,7 @@ export class Tier {
   public async subscribe(
     org: OrgName,
     features: Features | Features[],
-    { effective, info, trialDays, checkout }: SubscribeOptions = {}
+    { effective, info, trialDays, checkout }: SubscribeParams = {}
   ): Promise<{}> {
     const phases: Phase[] = !Array.isArray(features)
       ? [{ features: [features], effective }]
@@ -633,7 +633,7 @@ export class Tier {
   public async schedule(
     org: OrgName,
     phases?: Phase[],
-    { info, checkout }: ScheduleOptions = {}
+    { info, checkout }: ScheduleParams = {}
   ) {
     const sr: ScheduleRequest = { org, phases, info, checkout }
     return await this.apiPost<ScheduleRequest, ScheduleResponse>(

--- a/src/client.ts
+++ b/src/client.ts
@@ -610,10 +610,13 @@ export class Tier {
       ? [{ features, effective }]
       : []
 
-    if (trialDays && (typeof trialDays !== 'number' || trialDays <= 0)) {
-      throw new TypeError('trialDays must be number >0 if specified')
-    }
-    if (trialDays && phases.length) {
+    if (trialDays !== undefined) {
+      if (typeof trialDays !== 'number' || trialDays <= 0) {
+        throw new TypeError('trialDays must be number >0 if specified')
+      }
+      if (!phases.length) {
+        throw new TypeError('trialDays may not be set without a subscription')
+      }
       const real = phases[0]
       /* c8 ignore start */
       const effective = real.effective || new Date()

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,10 @@ import type {
   OrgName,
   Phase,
   PushResponse,
-  ReportOptions,
-  ScheduleOptions,
+  ReportParams,
+  ScheduleParams,
   ScheduleResponse,
-  SubscribeOptions,
+  SubscribeParams,
   Usage,
   WhoAmIResponse,
   WhoIsResponse,
@@ -158,7 +158,7 @@ export async function report(
   org: OrgName,
   feature: FeatureName,
   n: number = 1,
-  options?: ReportOptions
+  options?: ReportParams
 ): Promise<{}> {
   const tier = await getClient()
   return await tier.report(org, feature, n, options)
@@ -172,7 +172,7 @@ export async function can(org: OrgName, feature: FeatureName): Promise<Answer> {
 export async function subscribe(
   org: OrgName,
   features: Features | Features[],
-  { effective, info, trialDays, checkout }: SubscribeOptions = {}
+  { effective, info, trialDays, checkout }: SubscribeParams = {}
 ): Promise<ScheduleResponse> {
   const tier = await getClient()
   return await tier.subscribe(org, features, {
@@ -191,7 +191,7 @@ export async function cancel(org: OrgName): Promise<ScheduleResponse> {
 export async function schedule(
   org: OrgName,
   phases?: Phase[],
-  { info, checkout }: ScheduleOptions = {}
+  { info, checkout }: ScheduleParams = {}
 ): Promise<ScheduleResponse> {
   const tier = await getClient()
   return await tier.schedule(org, phases, { info, checkout })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 import { ChildProcess, spawn } from 'child_process'
 
 import type {
+  Answer,
   CurrentPhase,
   FeatureName,
   Features,
@@ -17,6 +18,7 @@ import type {
   OrgName,
   Phase,
   PushResponse,
+  ReportOptions,
   ScheduleOptions,
   ScheduleResponse,
   SubscribeOptions,
@@ -139,28 +141,32 @@ export async function pullLatest(): Promise<Model> {
   return tier.pullLatest()
 }
 
-export async function limits(org: OrgName): Promise<Limits> {
+export async function lookupLimits(org: OrgName): Promise<Limits> {
   const tier = await getClient()
-  return tier.limits(org)
+  return tier.lookupLimits(org)
 }
 
-export async function limit(
+export async function lookupLimit(
   org: OrgName,
   feature: FeatureName
 ): Promise<Usage> {
   const tier = await getClient()
-  return tier.limit(org, feature)
+  return tier.lookupLimit(org, feature)
 }
 
 export async function report(
   org: OrgName,
   feature: FeatureName,
   n: number = 1,
-  at?: Date,
-  clobber?: boolean
+  options?: ReportOptions
 ): Promise<{}> {
   const tier = await getClient()
-  return tier.report(org, feature, n, at, clobber)
+  return await tier.report(org, feature, n, options)
+}
+
+export async function can(org: OrgName, feature: FeatureName): Promise<Answer> {
+  const tier = await getClient()
+  return tier.can(org, feature)
 }
 
 export async function subscribe(
@@ -191,7 +197,10 @@ export async function schedule(
   return await tier.schedule(org, phases, { info, checkout })
 }
 
-export async function updateOrg(org: OrgName, info: OrgInfo): Promise<ScheduleResponse> {
+export async function updateOrg(
+  org: OrgName,
+  info: OrgInfo
+): Promise<ScheduleResponse> {
   const tier = await getClient()
   return await tier.updateOrg(org, info)
 }
@@ -211,7 +220,7 @@ export async function whoami(): Promise<WhoAmIResponse> {
   return tier.whoami()
 }
 
-export async function phase(org: OrgName): Promise<CurrentPhase> {
+export async function lookupPhase(org: OrgName): Promise<CurrentPhase> {
   const tier = await getClient()
   return tier.phase(org)
 }
@@ -240,6 +249,30 @@ import {
 
 export * from './client.js'
 
+/* c8 ignore start */
+/**
+ * @deprecated alias for lookupLimits
+ */
+export async function limits(org: OrgName): Promise<Limits> {
+  return lookupLimits(org)
+}
+/**
+ * @deprecated alias for lookupLimit
+ */
+export async function limit(
+  org: OrgName,
+  feature: FeatureName
+): Promise<Usage> {
+  return lookupLimit(org, feature)
+}
+/**
+ * @deprecated alias for lookupPhase
+ */
+export async function phase(org: OrgName): Promise<CurrentPhase> {
+  return lookupPhase(org)
+}
+/* c8 ignore stop */
+
 const TIER = {
   isErrorResponse,
   isFeatureName,
@@ -259,13 +292,14 @@ const TIER = {
   init,
   exitHandler,
 
-  limit,
-  limits,
-  phase,
+  lookupLimit,
+  lookupLimits,
+  lookupPhase,
   pull,
   pullLatest,
   push,
   report,
+  can,
   subscribe,
   schedule,
   cancel,
@@ -273,6 +307,10 @@ const TIER = {
   whois,
   lookupOrg,
   whoami,
+
+  limit,
+  limits,
+  phase,
 }
 
 export default TIER

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,9 @@ import type {
   OrgName,
   Phase,
   PushResponse,
+  ScheduleOptions,
+  ScheduleResponse,
+  SubscribeOptions,
   Usage,
   WhoAmIResponse,
   WhoIsResponse,
@@ -163,23 +166,32 @@ export async function report(
 export async function subscribe(
   org: OrgName,
   features: Features | Features[],
-  effective?: Date,
-  info?: OrgInfo
-): Promise<{}> {
+  { effective, info, trialDays, checkout }: SubscribeOptions = {}
+): Promise<ScheduleResponse> {
   const tier = await getClient()
-  return await tier.subscribe(org, features, effective, info)
+  return await tier.subscribe(org, features, {
+    effective,
+    info,
+    trialDays,
+    checkout,
+  })
+}
+
+export async function cancel(org: OrgName): Promise<ScheduleResponse> {
+  const tier = await getClient()
+  return await tier.cancel(org)
 }
 
 export async function schedule(
   org: OrgName,
   phases?: Phase[],
-  info?: OrgInfo
-): Promise<{}> {
+  { info, checkout }: ScheduleOptions = {}
+): Promise<ScheduleResponse> {
   const tier = await getClient()
-  return await tier.schedule(org, phases, info)
+  return await tier.schedule(org, phases, { info, checkout })
 }
 
-export async function updateOrg(org: OrgName, info: OrgInfo): Promise<{}> {
+export async function updateOrg(org: OrgName, info: OrgInfo): Promise<ScheduleResponse> {
   const tier = await getClient()
   return await tier.updateOrg(org, info)
 }
@@ -220,10 +232,10 @@ import {
   isTierError,
   isVersionedFeatureName,
   Tier,
-  validatePlan,
-  validateModel,
-  validateFeatureTier,
   validateFeatureDefinition,
+  validateFeatureTier,
+  validateModel,
+  validatePlan,
 } from './client.js'
 
 export * from './client.js'
@@ -256,6 +268,7 @@ const TIER = {
   report,
   subscribe,
   schedule,
+  cancel,
   updateOrg,
   whois,
   lookupOrg,

--- a/test/index.ts
+++ b/test/index.ts
@@ -381,6 +381,13 @@ t.test('subscribe', t => {
     )
 
     await t.rejects(
+      Tier.subscribe('org:o', [], {
+        trialDays: 1,
+      }),
+      { message: 'trialDays may not be set without a subscription' }
+    )
+
+    await t.rejects(
       Tier.subscribe(
         'org:o',
         [


### PR DESCRIPTION
BREAKING CHANGES:
- Drop support for deprecated array of phases passed to tier.subscribe()
- Move subscribe() and schedule() parameters into options objects.