### PR TITLE
use TIER_BASE_URL and TIER_API_KEY envs

### DIFF
--- a/src/get-client.ts
+++ b/src/get-client.ts
@@ -1,0 +1,143 @@
+/**
+ * Internal module for starting a Tier API sidecar on demand.
+ *
+ * This should not be used directly.
+ *
+ * @internal
+ * @module
+ */
+
+// TODO: use the built-in tier binary for the appropriate platform
+// can do the platform-specific optional dep trick.
+
+// get a client on-demand for servicing the top-level methods.
+//
+// This spawns a sidecar on localhost as needed, if baseURL is not set.
+
+import type { ChildProcess } from 'child_process'
+import { Tier } from './client.js'
+
+// just use node-fetch as a polyfill for old node environments
+let fetchPromise: Promise<void> | null = null
+let FETCH = global.fetch
+if (typeof FETCH !== 'function') {
+  fetchPromise = import('node-fetch').then(f => {
+    //@ts-ignore
+    FETCH = f.default
+    fetchPromise = null
+  })
+}
+
+const port = 10000 + (process.pid % 10000)
+let sidecarPID: number | undefined
+let initting: undefined | Promise<void>
+
+const debug =
+  process.env.TIER_DEBUG === '1' ||
+  /\btier\b/i.test(process.env.NODE_DEBUG || '')
+const debugLog = debug
+  ? (...m: any[]) => console.error('tier:', ...m)
+  : () => {}
+
+export const getClient = async (): Promise<Tier> => {
+  await init()
+  const { TIER_BASE_URL } = process.env
+  if (!TIER_BASE_URL) {
+    throw new Error('failed sidecar initialization')
+  }
+  return new Tier({
+    baseURL: TIER_BASE_URL,
+    apiKey: process.env.TIER_API_KEY,
+    debug,
+    fetchImpl: FETCH,
+  })
+}
+
+// evade clever bundlers that try to import child_process for the client
+// insist that this is always a dynamic import, even though we don't
+// actually ever set this to any different value.
+let child_process: string = 'child_process'
+
+/**
+ * Initialize the Tier sidecar.
+ *
+ * Exported for testing, do not call directly.
+ *
+ * @internal
+ */
+export const init = async () => {
+  /* c8 ignore start */
+  if (!FETCH) {
+    await fetchPromise
+    if (!FETCH) {
+      throw new Error('could not find a fetch implementation')
+    }
+  }
+  /* c8 ignore stop */
+
+  if (sidecarPID || process.env.TIER_BASE_URL) {
+    return
+  }
+  if (initting) {
+    return initting
+  }
+  initting = import(child_process)
+    .then(({ spawn }) => {
+      const args = process.env.TIER_LIVE === '1' ? ['--live'] : []
+      const env = Object.fromEntries(Object.entries(process.env))
+      if (debug) {
+        args.push('-v')
+        env.STRIPE_DEBUG = '1'
+      }
+      args.push('serve', '--addr', `127.0.0.1:${port}`)
+      debugLog(args)
+      return new Promise<ChildProcess>((res, rej) => {
+        let proc = spawn('tier', args, {
+          env,
+          stdio: ['ignore', 'pipe', 'inherit'],
+        })
+        proc.on('error', rej)
+        /* c8 ignore start */
+        if (!proc || !proc.stdout) {
+          return rej(new Error('failed to start tier sidecar'))
+        }
+        /* c8 ignore stop */
+        proc.stdout.on('data', () => res(proc))
+      })
+    })
+    .then(proc => {
+      debugLog('started sidecar', proc.pid)
+      proc.on('exit', () => {
+        debugLog('sidecar closed', sidecarPID)
+        sidecarPID = undefined
+        delete process.env.TIER_BASE_URL
+        process.removeListener('exit', exitHandler)
+      })
+      process.on('exit', exitHandler)
+      proc.unref()
+      process.env.TIER_BASE_URL = `http://127.0.0.1:${port}`
+      sidecarPID = proc.pid
+      initting = undefined
+    })
+    .catch(er => {
+      debugLog('sidecar error', er)
+      initting = undefined
+      sidecarPID = undefined
+      throw er
+    })
+  return initting
+}
+
+/**
+ * Method to shut down the auto-started sidecar process on
+ * exit.  Exported for testing, do not call directly.
+ *
+ * @internal
+ */
+/* c8 ignore start */
+export const exitHandler = (_: number, signal: string | null) => {
+  if (sidecarPID) {
+    process.kill(sidecarPID, signal || 'SIGTERM')
+  }
+}
+/* c8 ignore stop */

--- a/test/fetch-polyfill.ts
+++ b/test/fetch-polyfill.ts
@@ -1,4 +1,6 @@
 //@ts-ignore
 global.fetch = undefined
+//@ts-ignore
+globalThis.fetch = undefined
 
-import './index'
+import './init'

--- a/test/init.ts
+++ b/test/init.ts
@@ -16,19 +16,20 @@ const mock = {
         proc.stdin.write('this is fine\n')
       }
       SPAWN_PROC = proc
-      proc.on('close', () => {
+      proc.on('exit', () => {
         SPAWN_PROC = undefined
       })
       return proc
     },
   },
 }
-const Tier = t.mock('../', mock).default
+const { init, getClient } = t.mock('../dist/cjs/get-client.js', mock)
+const tier = t.mock('../', mock).default
 
 t.afterEach(async () => {
   SPAWN_FAIL = false
   delete process.env.TIER_LIVE
-  delete process.env.TIER_SIDECAR
+  delete process.env.TIER_BASE_URL
   SPAWN_CALLS.length = 0
   // always just kill the sidecar process between tests
   if (SPAWN_PROC) {
@@ -37,7 +38,8 @@ t.afterEach(async () => {
     const p = new Promise<void>(res => {
       t = setTimeout(() => res(), 200)
       if (SPAWN_PROC) {
-        SPAWN_PROC.on('close', () => res())
+        SPAWN_PROC.on('exit', () => res())
+        SPAWN_PROC.kill('SIGKILL')
       }
     })
     // @ts-ignore
@@ -49,32 +51,46 @@ t.afterEach(async () => {
 
 t.test('reject API calls if init fails', async t => {
   SPAWN_FAIL = true
-  await t.rejects(Tier.limits('org:o'))
+  await t.rejects(tier.limits('org:o'))
+  await t.rejects(getClient())
+  // tries 2 times
+  t.same(SPAWN_CALLS, [
+    ['tier', 'serve', '--addr', `127.0.0.1:${port}`],
+    ['tier', 'serve', '--addr', `127.0.0.1:${port}`],
+  ])
+})
+
+t.test('reject if TIER_BASE_URL gets unset', async t => {
+  await init()
+  process.env.TIER_BASE_URL = ''
+  await t.rejects(getClient())
   t.same(SPAWN_CALLS, [['tier', 'serve', '--addr', `127.0.0.1:${port}`]])
 })
 
 t.test('live mode when TIER_LIVE is set', async t => {
   process.env.TIER_LIVE = '1'
-  await Tier.init()
+  const c = await getClient()
+  t.ok(c, 'got a client')
+  t.equal(c.baseURL, `http://127.0.0.1:${port}`)
   t.same(SPAWN_CALLS, [
     ['tier', '--live', 'serve', '--addr', `127.0.0.1:${port}`],
   ])
 })
 
 t.test('only init one time in parallel', async t => {
-  await Promise.all([Tier.init(), Tier.init()])
+  await Promise.all([init(), init()])
   t.same(SPAWN_CALLS, [['tier', 'serve', '--addr', `127.0.0.1:${port}`]])
 })
 
 t.test('only init one time ever', async t => {
-  await Tier.init()
-  await Tier.init()
+  await init()
+  await init()
   t.same(SPAWN_CALLS, [['tier', 'serve', '--addr', `127.0.0.1:${port}`]])
 })
 
 t.test('no init if env says running', async t => {
-  process.env.TIER_SIDECAR = `http://127.0.0.1:${port}`
-  await Tier.init()
+  process.env.TIER_BASE_URL = `http://127.0.0.1:${port}`
+  await init()
   t.same(SPAWN_CALLS, [])
 })
 
@@ -87,7 +103,10 @@ t.test('debug runs sidecar in debug mode', async t => {
     delete process.env.TIER_DEBUG
   })
   console.error = (...args: any[]) => logs.push(args)
-  const Tier = t.mock('../', mock).default
-  await Tier.init()
-  t.match(logs, [['tier:', ['-v', 'serve', '--addr', /^127\.0\.0\.1:\d+$/]]])
+  const { init } = t.mock('../dist/cjs/get-client.js', mock)
+  await init()
+  t.match(logs, [
+    ['tier:', ['-v', 'serve', '--addr', /^127\.0\.0\.1:\d+$/]],
+    ['tier:', 'started sidecar', Number],
+  ])
 })


### PR DESCRIPTION
- Removes TIER_SIDECAR env -> TIER_BASE_URL (it won't be a sidecar if it's remote!)
- Adds handling for client.apiKey coming from TIER_API_KEY env by default
- Split out the getClient stuff so it's more seamless when pulling into places just to use the type checking and other methods, without having to also try to load child_process by default.