### PR TITLE
feat: make tier client workers compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tier",
       "version": "5.9.0",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "isomorphic-unfetch": "^4.0.2"
+      },
       "devDependencies": {
         "@types/node": "^18.0.6",
         "@types/node-fetch": "^2.6.2",
@@ -1230,6 +1233,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1585,6 +1596,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1695,6 +1728,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fromentries": {
@@ -2032,6 +2076,32 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
+      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
+      "dependencies": {
+        "node-fetch": "^3.2.0",
+        "unfetch": "^5.0.0"
+      }
+    },
+    "node_modules/isomorphic-unfetch/node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -2431,6 +2501,24 @@
       },
       "engines": {
         "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -5444,6 +5532,11 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
+    },
     "node_modules/unicode-length": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.1.0.tgz",
@@ -5529,6 +5622,14 @@
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "typescript": "^4.7.4"
   },
   "optionalDependencies": {
-    "node-fetch": "^2.6.7"
+    "isomorphic-unfetch": "^4.0.2"
   },
   "engines": {
     "node": ">=12"

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,8 +12,8 @@ const defaultUserAgent = `tier/${version} ${git.substring(0, 8)} ${
     ? navigator.userAgent
     : typeof process !== 'undefined'
     ? `node/${process.version}`
-  /* c8 ignore start */
-    : ''
+    : /* c8 ignore start */
+      ''
   /* c8 ignore stop */
 }`.trim()
 

--- a/src/get-client.ts
+++ b/src/get-client.ts
@@ -19,9 +19,9 @@ import { Tier, TierGetClientOptions } from './client.js'
 
 // just use node-fetch as a polyfill for old node environments
 let fetchPromise: Promise<void> | null = null
-let FETCH = global.fetch
+let FETCH = globalThis.fetch
 if (typeof FETCH !== 'function') {
-  fetchPromise = import('node-fetch').then(f => {
+  fetchPromise = import('isomorphic-unfetch').then(f => {
     //@ts-ignore
     FETCH = f.default
     fetchPromise = null


### PR DESCRIPTION
- Switching from global to globalThis to support more than just node runtimes
- Using isomorphic-unfetch instead of node-fetch to support more runtimes out of the box