### PR TITLE
improvement: Update lookupLimit function to use nullish coalescing fo…

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -503,7 +503,7 @@ export class Tier {
    */
   async lookupLimit(org: OrgName, feature: FeatureName): Promise<Usage> {
     const limits = await this.tryGet<Limits>('/v1/limits', { org })
-    for (const usage of limits.usage) {
+    for (const usage of limits?.usage ?? []) {
       if (
         usage.feature === feature ||
         usage.feature.startsWith(`${feature}@plan:`)


### PR DESCRIPTION
In order to avoid running `updateOrg()` on existing users, triggering a re-creation of Stripe customers, leading to duplicates, I've added the metadata `tier.org = "org:user_xyz"` to existing Stripe customers.

This successfully make Tier recognize the user. However, when running `tier.can()`, I get:
```bash
/node_modules/tier/src/client.ts:506
    for (const usage of limits.usage) {
                               ^
TypeError: limits.usage is not iterable
    at Tier.<anonymous> (/Users/romeo/Development/receiptor/receiptor-backend/node_modules/tier/src/client.ts:506:32)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/romeo/Development/receiptor/receiptor-backend/node_modules/tier/dist/cjs/client.js:8:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Hence, I've added nullish coalescing for more precise default handling.